### PR TITLE
refactor: move service management code into external binaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,7 @@ bin/*
 res/fonts/*
 !res/fonts/.gitkeep
 
-!bin/service-on
 !bin/on-boot
+!bin/service-is-running
+!bin/service-off
+!bin/service-on

--- a/bin/service-is-running
+++ b/bin/service-is-running
@@ -1,0 +1,25 @@
+#!/bin/sh
+BIN_DIR="$(dirname "$0")"
+PAK_DIR="$(dirname "$BIN_DIR")"
+PAK_NAME="$(basename "$PAK_DIR")"
+PAK_NAME="${PAK_NAME%.*}"
+set -x
+
+SERVICE_NAME="remote-term"
+LAUNCHES_SCRIPT="false"
+
+main() {
+    if pgrep "$SERVICE_NAME" >/dev/null 2>&1; then
+        return 0
+    fi
+
+    if [ "$LAUNCHES_SCRIPT" = "true" ]; then
+        if pgrep -fn "$SERVICE_NAME" >/dev/null 2>&1; then
+            return 0
+        fi
+    fi
+
+    return 1
+}
+
+main "$@"

--- a/bin/service-off
+++ b/bin/service-off
@@ -1,0 +1,13 @@
+#!/bin/sh
+BIN_DIR="$(dirname "$0")"
+PAK_DIR="$(dirname "$BIN_DIR")"
+PAK_NAME="$(basename "$PAK_DIR")"
+PAK_NAME="${PAK_NAME%.*}"
+set -x
+
+echo "$0" "$@"
+cd "$PAK_DIR" || exit 1
+
+SERVICE_NAME="remote-term"
+
+killall "$SERVICE_NAME"

--- a/launch.sh
+++ b/launch.sh
@@ -27,10 +27,6 @@ LAUNCHES_SCRIPT="false"
 NETWORK_PORT=8080
 NETWORK_SCHEME="http"
 
-service_off() {
-    killall "$SERVICE_NAME"
-}
-
 show_message() {
     message="$1"
     seconds="$2"
@@ -73,25 +69,11 @@ will_start_on_boot() {
     return 1
 }
 
-is_service_running() {
-    if pgrep "$SERVICE_NAME" >/dev/null 2>&1; then
-        return 0
-    fi
-
-    if [ "$LAUNCHES_SCRIPT" = "true" ]; then
-        if pgrep -fn "$SERVICE_NAME" >/dev/null 2>&1; then
-            return 0
-        fi
-    fi
-
-    return 1
-}
-
 wait_for_service() {
     max_counter="$1"
     counter=0
 
-    while ! is_service_running; do
+    while ! service-is-running; do
         counter=$((counter + 1))
         if [ "$counter" -gt "$max_counter" ]; then
             return 1
@@ -104,7 +86,7 @@ wait_for_service_to_stop() {
     max_counter="$1"
     counter=0
 
-    while is_service_running; do
+    while service-is-running; do
         counter=$((counter + 1))
         if [ "$counter" -gt "$max_counter" ]; then
             return 1
@@ -160,7 +142,7 @@ current_settings() {
     rm -f "$minui_list_file"
 
     jq -rM '{settings: .settings}' "$PAK_DIR/settings.json" >"$minui_list_file"
-    if is_service_running; then
+    if service-is-running; then
         jq '.settings[0].selected = 1' "$minui_list_file" >"$minui_list_file.tmp"
         mv "$minui_list_file.tmp" "$minui_list_file"
     fi
@@ -180,7 +162,7 @@ main_screen() {
 
     echo "$settings" >"$minui_list_file"
 
-    if is_service_running; then
+    if service-is-running; then
         service_pid="$(get_service_pid)"
         jq --arg pid "$service_pid" '.settings[.settings | length] |= . + {"name": "PID", "options": [$pid], "selected": 0, "features": {"unselectable": true}}' "$minui_list_file" >"$minui_list_file.tmp"
         mv "$minui_list_file.tmp" "$minui_list_file"
@@ -277,7 +259,7 @@ main() {
                 killall minui-presenter >/dev/null 2>&1 || true
             else
                 show_message "Disabling $HUMAN_READABLE_NAME" 2
-                if ! service_off; then
+                if ! service-off; then
                     show_message "Failed to disable $HUMAN_READABLE_NAME!" 2
                 fi
 


### PR DESCRIPTION
This should allow other utilities to know whether or not a service is managed by the pak, and therefore orchestrate the service when updating the pak.